### PR TITLE
includeSiteTreeVersions requires array to merge

### DIFF
--- a/code/WhitelistGenerator.php
+++ b/code/WhitelistGenerator.php
@@ -41,6 +41,7 @@ class WhitelistGenerator extends Object implements Flushable {
 
 				} elseif ($rule === '$URLSegment') {
 					$topLevelPagesArray = array();  //temporary array to store top-level pages
+					$oldTopLevelPagesArray = array();
 
 					//special case for SiteTree, add all possible top Level Pages
 					$topLevelPages = SiteTree::get()->filter('ParentID', 0);


### PR DESCRIPTION
if `includeSiteTreeVersions` is set to false, then the array `$oldTopLevelPagesArray` is never created - this results in an array_merge E_USER_ERROR. This means, you can never actually set `includeSiteTreeVersions` to anything other than true. 

This fix adds the original array, which allows you to exclude sitetree versions from the routewhitelist (intended behaviour).